### PR TITLE
Add support to sort on table header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wecancer/design-system",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "private": false,
   "homepage": "wecancer-design-system.netlify.app",
   "license": "MIT",

--- a/src/components/date-picker/index.tsx
+++ b/src/components/date-picker/index.tsx
@@ -62,6 +62,7 @@ const DatePicker = ({ label, value, onChange, fromYear, toYear }: Props) => {
       <Input
         type="text"
         {...inputProps}
+        placeholder=""
         label={label}
         value={`${inputProps.value}`}
         iconButtonRight={{

--- a/src/components/datetime-picker/__snapshots__/datetime-picker.test.tsx.snap
+++ b/src/components/datetime-picker/__snapshots__/datetime-picker.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`<DateTimePicker /> should render snapshot correctly 1`] = `
       >
         <input
           class="sc-dkPtRN kNILkx"
-          placeholder="01/06/2022"
+          placeholder=""
           type="text"
           value="31/12/1899"
         />

--- a/src/components/icon/svg/index.tsx
+++ b/src/components/icon/svg/index.tsx
@@ -29,6 +29,7 @@ import PlugSvg from './plus-svg'
 import ProcedureSvg from './procedure-svg'
 import SearchSvg from './search-svg'
 import SettingsSvg from './settings-svg'
+import SortSvg from './sort-svg'
 import SpinnerDots from './spinner-dots-svg'
 import SpinnerSolid from './spinner-solid-svg'
 import StethoscopeSvg from './stethoscope-svg'
@@ -74,6 +75,7 @@ const iconMap = {
   procedure: ProcedureSvg,
   search: SearchSvg,
   settings: SettingsSvg,
+  sort: SortSvg,
   spinnerDots: SpinnerDots,
   spinnerSolid: SpinnerSolid,
   stethoscope: StethoscopeSvg,

--- a/src/components/icon/svg/sort-svg.tsx
+++ b/src/components/icon/svg/sort-svg.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const SortSvg = () => (
+  <svg viewBox="-96 0 512 512" xmlns="http://www.w3.org/2000/svg">
+    <path
+      fill="currentColor"
+      d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+    />
+  </svg>
+)
+
+export default SortSvg

--- a/src/components/table/__snapshots__/table.test.tsx.snap
+++ b/src/components/table/__snapshots__/table.test.tsx.snap
@@ -11,28 +11,60 @@ exports[`<Table /> should render snapshot correctly 1`] = `
       class="sc-jRQBWg efedTK"
     >
       <div
-        class="sc-hKwDye eDPjSw wc-table-cell wc-table-cell-solid"
+        class="sc-iCfMLu hBVVuY wc-table-cell"
       >
         <div>
           Head 1
         </div>
       </div>
       <div
-        class="sc-hKwDye eDPjSw wc-table-cell wc-table-cell-solid"
+        class="sc-iCfMLu hBVVuY wc-table-cell"
+        role="button"
+        tabindex="0"
       >
         <div>
           Head 2
+          <div
+            class="sc-gKclnd fechly sc-furwcr kFaARC"
+            data-icon-name="sort"
+          >
+            <svg
+              viewBox="-96 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
         </div>
       </div>
       <div
-        class="sc-hKwDye eDPjSw wc-table-cell wc-table-cell-solid"
+        class="sc-iCfMLu hBVVuY wc-table-cell"
+        role="button"
+        tabindex="0"
       >
         <div>
           Head 3
+          <div
+            class="sc-gKclnd fechly sc-furwcr kFaARC"
+            data-icon-name="sort"
+          >
+            <svg
+              viewBox="-96 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
         </div>
       </div>
       <div
-        class="sc-hKwDye eDPjSw wc-table-cell wc-table-cell-solid"
+        class="sc-iCfMLu hBVVuY wc-table-cell"
       >
         <div>
           Head 4

--- a/src/components/table/__snapshots__/table.test.tsx.snap
+++ b/src/components/table/__snapshots__/table.test.tsx.snap
@@ -11,14 +11,14 @@ exports[`<Table /> should render snapshot correctly 1`] = `
       class="sc-jRQBWg efedTK"
     >
       <div
-        class="sc-iCfMLu hBVVuY wc-table-cell"
+        class="sc-iCfMLu QsSWr wc-table-cell"
       >
         <div>
           Head 1
         </div>
       </div>
       <div
-        class="sc-iCfMLu hBVVuY wc-table-cell"
+        class="sc-iCfMLu QsSWr wc-table-cell"
         role="button"
         tabindex="0"
       >
@@ -41,7 +41,7 @@ exports[`<Table /> should render snapshot correctly 1`] = `
         </div>
       </div>
       <div
-        class="sc-iCfMLu hBVVuY wc-table-cell"
+        class="sc-iCfMLu QsSWr wc-table-cell"
         role="button"
         tabindex="0"
       >
@@ -64,7 +64,7 @@ exports[`<Table /> should render snapshot correctly 1`] = `
         </div>
       </div>
       <div
-        class="sc-iCfMLu hBVVuY wc-table-cell"
+        class="sc-iCfMLu QsSWr wc-table-cell"
       >
         <div>
           Head 4

--- a/src/components/table/header-cell.tsx
+++ b/src/components/table/header-cell.tsx
@@ -1,18 +1,16 @@
 import React, { useState } from 'react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { keyActionClick } from '../../events'
 import Icon from '../icon'
 
 const Container = styled.div`
-  ${() => css`
-    padding: 0.75rem 1rem;
-    display: flex;
-    align-items: center;
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
 
-    &[role='button'] {
-      cursor: pointer;
-    }
-  `}
+  &[role='button'] {
+    cursor: pointer;
+  }
 `
 
 const SortIcon = styled(Icon)`

--- a/src/components/table/header-cell.tsx
+++ b/src/components/table/header-cell.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react'
+import styled, { css } from 'styled-components'
+import { keyActionClick } from '../../events'
+import Icon from '../icon'
+
+const Container = styled.div`
+  ${() => css`
+    padding: 0.75rem 1rem;
+    display: flex;
+    align-items: center;
+
+    &[role='button'] {
+      cursor: pointer;
+    }
+  `}
+`
+
+const SortIcon = styled(Icon)`
+  transform: translate(5px, 1px);
+`
+
+type SortDirection = 1 | -1
+
+type SortParams = { direction: SortDirection }
+
+export type Props = {
+  children: React.ReactNode
+  onSort?({ direction }: SortParams): void
+}
+
+const TableHeaderCell = ({ children, onSort }: Props): React.ReactElement => {
+  const [sortDirection, setSortDirection] = useState<1 | -1>(-1)
+  const classNames = ['wc-table-cell'].filter((cname) => !!cname)
+  const hasSort = !!onSort
+
+  const handleSort = () => {
+    const direction = sortDirection === 1 ? -1 : 1
+    setSortDirection(direction)
+    onSort?.({ direction })
+  }
+
+  const buttonProps = onSort
+    ? {
+        role: 'button',
+        tabIndex: 0,
+        onClick: handleSort,
+        onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) =>
+          keyActionClick(e, handleSort),
+      }
+    : {}
+
+  return (
+    <Container {...buttonProps} className={classNames.join(' ')}>
+      <div>
+        {children}
+        {hasSort && <SortIcon name="sort" size={12} />}
+      </div>
+    </Container>
+  )
+}
+
+export default TableHeaderCell

--- a/src/components/table/table-list.stories.tsx
+++ b/src/components/table/table-list.stories.tsx
@@ -4,15 +4,16 @@ import Table, { Props } from '.'
 import TableRow from './row'
 import TableCell from './cell'
 import TableHeader from './header'
+import TableHeaderCell from './header-cell'
 import Pill from '../pill'
 
 const Template: Story<Props> = () => (
   <Table cellsWitdh="100px 200px 1fr 1fr">
     <TableHeader>
-      <TableCell>Head 1</TableCell>
-      <TableCell>Head 2</TableCell>
-      <TableCell>Head 3</TableCell>
-      <TableCell>Head 4</TableCell>
+      <TableHeaderCell>Head 1</TableHeaderCell>
+      <TableHeaderCell>Head 2</TableHeaderCell>
+      <TableHeaderCell>Head 3</TableHeaderCell>
+      <TableHeaderCell>Head 4</TableHeaderCell>
     </TableHeader>
     <TableRow onClick={() => alert('First row was clicked')}>
       <TableCell type="warning">Warning</TableCell>

--- a/src/components/table/table.test.tsx
+++ b/src/components/table/table.test.tsx
@@ -2,17 +2,18 @@ import Table from '.'
 import TableRow from './row'
 import TableCell from './cell'
 import TableHeader from './header'
-import { render } from '../../testing'
+import TableHeaderCell from './header-cell'
+import { render, fireEvent } from '../../testing'
 
 describe('<Table />', () => {
   it('should render snapshot correctly', () => {
     const { container } = render(
       <Table cellsWitdh="100px 200px 1fr 1fr">
         <TableHeader>
-          <TableCell>Head 1</TableCell>
-          <TableCell>Head 2</TableCell>
-          <TableCell>Head 3</TableCell>
-          <TableCell>Head 4</TableCell>
+          <TableHeaderCell>Head 1</TableHeaderCell>
+          <TableHeaderCell onSort={() => null}>Head 2</TableHeaderCell>
+          <TableHeaderCell onSort={() => null}>Head 3</TableHeaderCell>
+          <TableHeaderCell>Head 4</TableHeaderCell>
         </TableHeader>
         <TableRow onClick={() => null}>
           <TableCell type="warning">Warning</TableCell>
@@ -63,5 +64,35 @@ describe('<Table />', () => {
       </Table>,
     )
     expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('should sort cell on table header', () => {
+    const handleClick = jest.fn()
+    let count = 0
+    const { getByText } = render(
+      <Table cellsWitdh="100px 200px 1fr 1fr">
+        <TableHeader>
+          <TableHeaderCell>Head 1</TableHeaderCell>
+          <TableHeaderCell
+            onSort={({ direction }) => {
+              count++
+              handleClick()
+              expect(direction).toBe(count === 1 ? 1 : -1)
+            }}
+          >
+            Head 2
+          </TableHeaderCell>
+        </TableHeader>
+        <TableRow>
+          <TableCell>Item 1</TableCell>
+          <TableCell>Item 2</TableCell>
+        </TableRow>
+      </Table>,
+    )
+    const headSort = getByText('Head 2')
+    fireEvent.click(headSort)
+    fireEvent.click(headSort)
+
+    expect(handleClick).toBeCalledTimes(2)
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import Table from './components/table'
 import TableRow from './components/table/row'
 import TableCell from './components/table/cell'
 import TableHeader from './components/table/header'
+import TableHeaderCell from './components/table/header-cell'
 
 import Tab from './components/tab/selection/tab'
 import Tabs from './components/tab/selection/tabs'
@@ -102,6 +103,7 @@ export {
   Table,
   TableCell,
   TableHeader,
+  TableHeaderCell,
   TableRow,
   Tabs,
   Textarea,


### PR DESCRIPTION
Use the `onSort` event on `<TableHeaderCell />`.

Example to use:
```
import { Table, TableHeader, TableRow, TableCell, TableHeaderCell } from '@wecancer/design-system'
...
<Table cellsWitdh="1fr 1fr">
  <TableHeader>
    <TableHeaderCell>Head 1</TableHeaderCell>
    <TableHeaderCell
      onSort={({ direction }) => console.log(direction)}
    >
      Head 2
    </TableHeaderCell>
  </TableHeader>
  <TableRow>
    <TableCell>Item 1</TableCell>
    <TableCell>Item 2</TableCell>
  </TableRow>
</Table>
```